### PR TITLE
Always return github token

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -29,10 +29,10 @@ class SubmissionsController < ApplicationController
         body: response_body,
         url: issue_url
       }
-    rescue
+    rescue => exception
       render json: {
         status: "error",
-        body: "Your submission could not be processed.",
+        body: exception.message,
       }
     end
   end
@@ -40,13 +40,7 @@ class SubmissionsController < ApplicationController
   private
 
     def token_for(repository)
-      feedback_bot = ["api-github-issue"]
-
-      if feedback_bot.include?(repository)
-        return "#{ENV["GITHUB_FEEDBACK_TOKEN"]}"
-      else
-        return false
-      end
+      return "#{ENV["GITHUB_FEEDBACK_TOKEN"]}"
     end
 
 end


### PR DESCRIPTION
We don't need to whitelist repos yet because we don't know where we'll file issues. Once we nail that down we can get more restrictive.

Created an issue by running this locally

```
curl --data 'q={"repository":"joplin","title":"ou812","description":"something profound goes here"}' localhost:8020/
{"status":"success","body":"Your feedback has been received.","url":"https://github.com/cityofaustin/joplin/issues/85"
```

Fixes cityofaustin/form-to-github-issue#1
Fixes cityofaustin/joplin#85
Makes cityofaustin/janis#18 better because we'll be able to file realz issues